### PR TITLE
bind to textarea.on 'change' . Also remove console.log

### DIFF
--- a/jquery.overlay.js
+++ b/jquery.overlay.js
@@ -139,7 +139,6 @@
 
       // Setup overlay
       this.textareaTop = parseInt($textarea.css('border-top-width'));
-      console.log(getStyles($textarea, textareaToOverlay));
       this.$el = $(html.overlay).css(
         $.extend({}, css.overlay, getStyles($textarea, textareaToOverlay), {
           top: this.textareaTop,
@@ -162,6 +161,7 @@
 
       // Bind event handlers
       this.$textarea.on('input', bind(this.onInput, this));
+      this.$textarea.on('change', bind(this.onInput, this));
       this.$textarea.on('scroll', bind(this.resizeOverlay, this));
       this.$textarea.on('resize', bind(this.resizeOverlay, this));
 


### PR DESCRIPTION
added `this.$textarea.on('change', bind(this.onInput, this));` because when using this with At.js the 'input` event does not fire on change. This fixes that.

Also I removed the extra console.log that probably shouldn't be there.
