### PR TITLE
Allow match pattern to contain span tag-ish text

### DIFF
--- a/jquery.overlay.js
+++ b/jquery.overlay.js
@@ -226,7 +226,7 @@
         this.$textarea.off('.overlay');
         $wrapper = this.$textarea.parent();
         $wrapper.after(this.$textarea).remove();
-        this.$textarea.data('overlay', void 0);
+        this.$textarea.removeData('overlay');
         this.$textarea = null;
       }
     });


### PR DESCRIPTION
This handy plugin reminds me of ColorizeHC :relaxed:

Well, the main idea is to keep result as DOM tree until the end, walking through elements and only find&replace text nodes.
This should resolve #1 and #3.

Demo: http://jsfiddle.net/ranvis/3GHbK/

Mixed with patch for destroy :)
