### PR TITLE
Update jquery.overlay.js

### DIFF
--- a/jquery.overlay.js
+++ b/jquery.overlay.js
@@ -47,9 +47,11 @@
    * Function for escaping strings to HTML interpolation.
    */
   var escape = function (str) {
-    return str.replace(entityRegexe, function (match) {
-      return entityMap[match];
-    })
+    if (typeof str !== 'undefined'){
+      return str.replace(entityRegexe, function (match) {
+        return entityMap[match];
+      })
+    }
   };
 
   /**


### PR DESCRIPTION
If the plugin is loaded where str is empty, it causes a JS error with cannot run replace for undefined object when str is undefined.
