### PR TITLE
Be possible style props

### DIFF
--- a/jquery.overlay.js
+++ b/jquery.overlay.js
@@ -189,7 +189,9 @@
           }
 
           // Style attribute's string
-          style = 'background-color:' + strategy.css['background-color'];
+          style = Object.keys(strategy.css).map(function(propCSS) {
+            return propCSS + ': ' + strategy.css[propCSS]
+          }).join(';')
 
           text.contents().each(function () {
             var text, html, str, prevIndex;


### PR DESCRIPTION
I don't know why in the codebase you restrict `background-color` as unique style to apply.

For my case of use, I use this modification and works fine. Now I can add border style and more stuff.
